### PR TITLE
Add gmap search endpoint

### DIFF
--- a/APIProxy/lib/APIProxy.pm
+++ b/APIProxy/lib/APIProxy.pm
@@ -1,5 +1,6 @@
 package APIProxy;
 use Dancer2;
+use LWP::UserAgent;
 
 our $VERSION = '0.1';
 
@@ -7,5 +8,29 @@ get '/' => sub {
   template 'index' => { 'title' => 'APIProxy' };
 };
 
+get '/gmap_search' => sub {
+  my $query = query_parameters->get('q');
+  return status_bad_request("Missing 'q' parameter") unless $query;
+
+  my $api_key = $ENV{'GOOGLE_MAPS_API_KEY'};
+  return status_bad_request("Missing API key") unless $api_key;
+
+  my $url = "https://www.google.com/maps/embed/v1/search?key=$api_key&q=$query";
+  my $ua = LWP::UserAgent->new;
+  my $response = $ua->get($url);
+
+  if ($response->is_success) {
+    content_type 'text/html';
+    return $response->decoded_content;
+  } else {
+    return status_bad_request("Failed to fetch data from Google Maps API");
+  }
+};
+
+sub status_bad_request {
+  my ($message) = @_;
+  status 'bad_request';
+  return { error => $message };
+}
 
 true;

--- a/APIProxy/t/003_gmap_search_route.t
+++ b/APIProxy/t/003_gmap_search_route.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+
+use APIProxy;
+use Test::More tests => 4;
+use Plack::Test;
+use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
+
+my $app = APIProxy->to_app;
+ok( is_coderef($app), 'Got app' );
+
+my $test = Plack::Test->create($app);
+my $res  = $test->request( GET '/gmap_search?q=Perl' );
+
+ok( $res->is_success, '[GET /gmap_search?q=Perl] successful' );
+is( $res->code, 200, 'Response code is 200' );
+is( $res->content_type, 'text/html', 'Content-Type is text/html' );


### PR DESCRIPTION
Fixes #1

Add a new route to handle the `/gmap_search` endpoint and corresponding tests.

* Add a new route in `APIProxy/lib/APIProxy.pm` to handle the `/gmap_search` endpoint.
  - Retrieve the `q` parameter from the request.
  - Get the API key from an environment variable.
  - Forward the response to the Google Maps API.
  - Set the content-type correctly for the response.
* Add a new test file `APIProxy/t/003_gmap_search_route.t` to test the `/gmap_search` endpoint.
  - Use `Plack::Test` to test the new route.
  - Check if the response is successful.
  - Verify the content-type of the response.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/api-proxy/pull/2?shareId=f41fe10c-cd57-4012-9ad0-c9b8212e7226).